### PR TITLE
Build arm64 docker images for Backend and Front end

### DIFF
--- a/FrontEnd/Dockerfile
+++ b/FrontEnd/Dockerfile
@@ -15,7 +15,12 @@ ENV TZ=America/Chicago
 ENV QUX_PROXY_URL=http://qux-be.quantux.com:8080
 
 ## Clone the frontend repo
+RUN apk --no-cache --virtual build-dependencies add \
+        python3 \
+        make \
+        g++
 RUN git clone https://github.com/KlausSchaefers/quant-ux.git
+
 
 RUN cd quant-ux && npm install && npm run build
 


### PR DESCRIPTION
This PR takes care of the https://github.com/bmcgonag/quant-ux-docker/issues/8 issue opened by me.

I have built and pushed arm64 images of both the Front-end and the Backend. The backed image was built with the original DockerFile without any issues. For the front end, a minor change has to be done in the Dockerfile and the arm64 image was built successfully.

https://hub.docker.com/repository/docker/impranshu/quant-ux-fe/tags?page=1&ordering=last_updated

https://hub.docker.com/repository/docker/impranshu/quant-ux-be/tags?page=1&ordering=last_updated

Now arm64 images can be built from the official repo as well and can be pushed to Docker Hub.